### PR TITLE
Bump supported graphene versions

### DIFF
--- a/graphene_prometheus/middleware.py
+++ b/graphene_prometheus/middleware.py
@@ -21,6 +21,9 @@ GRAPHQL_RESOLVER_COMPLETED_TOTAL = Counter(
 
 
 class PrometheusMiddleware:
+    def __init__(self):
+        print("Initialized Prometheus Middleware")
+        
     def resolve(
         self,
         next: Callable,

--- a/graphene_prometheus/middleware.py
+++ b/graphene_prometheus/middleware.py
@@ -20,10 +20,7 @@ GRAPHQL_RESOLVER_COMPLETED_TOTAL = Counter(
 )
 
 
-class PrometheusMiddleware:
-    def __init__(self):
-        print("Initialized Prometheus Middleware")
-        
+class PrometheusMiddleware:        
     def resolve(
         self,
         next: Callable,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 [tool.poetry.dependencies]
 python = "^3.7"
 prometheus_client = "^0.7.1"
-graphene = "^2.1.8"
+graphene = "3.*"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.1"


### PR DESCRIPTION
Hi

Thanks for this project. We have been able to use Graphene-Prometheus to monitor some stats on Django using the latest Django-Graphene, but we had to bump the versions. 

Everything appears to work at first glance. 